### PR TITLE
Fix worth logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dumbdogdiner</groupId>
     <artifactId>StickyCommands</artifactId>
-    <version>1.3.3-BETA</version>
+    <version>1.3.4-BETA</version>
     <packaging>jar</packaging>
 
     <name>StickyCommands</name>

--- a/src/main/java/com/dumbdogdiner/StickyCommands/Utils/Item.java
+++ b/src/main/java/com/dumbdogdiner/StickyCommands/Utils/Item.java
@@ -14,6 +14,9 @@ public class Item {
     private static File CustomConfigFile;
     private static FileConfiguration CustomConfig;
     private static Item localself = null;
+    private static String[] modifierPool = {
+        "white", "orange", "magenta", "lightblue", "yellow", "lime", "pink", "gray", "lightgray", "cyan", "purple", "blue", "brown", "green", "red", "black", "oak", "spruce", "birch", "jungle", "acacia", "darkoak"
+    };
 
     // Initialized by our GetMessages() function.
     protected Item() {
@@ -60,10 +63,22 @@ public class Item {
     public static double getItem(String item) {
         getItems();
         double worth = Item.CustomConfig.getDouble(item);
-        if (worth == 0)
-            return 0;
+        if (worth == 0) {
+            return GeneralizeItem(item);
+        }
 
         return worth;
+    }
+
+    private static double GeneralizeItem(String item) {
+        for(String s : modifierPool) {
+            if(item.startsWith(s)) {
+                String it = item.replace(s, "");
+                return Item.CustomConfig.getDouble(it);
+            }
+        }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
convert material name to a general string ("whitewool" > "wool") if raw input does not match, otherwise return 0 (non sellable)