### PR TITLE
Revert to shading CommandAPI

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("com.dumbdogdiner.closedsource-package-mirror:stafffacilities:4.8.5")
 
     // Command API
-    implementation("dev.jorel" , "commandapi-core", "5.8")
+    implementation("dev.jorel" , "commandapi-shade", "5.8")
 
     // Database dependencies
     implementation("org.jetbrains.exposed", "exposed-core", "0.28.1")

--- a/bukkit/src/main/kotlin/StickyCommands.kt
+++ b/bukkit/src/main/kotlin/StickyCommands.kt
@@ -16,6 +16,7 @@ import com.dumbdogdiner.stickycommands.managers.StickyPowertoolManager
 import com.dumbdogdiner.stickycommands.timers.AfkTimer
 import com.dumbdogdiner.stickycommands.util.WorthTable
 import com.dumbdogdiner.stickycommands.util.sticky.StickyStartupUtil
+import dev.jorel.commandapi.CommandAPI
 import kr.entree.spigradle.annotations.PluginMain
 import net.milkbowl.vault.economy.Economy
 import org.bukkit.plugin.Plugin
@@ -40,6 +41,7 @@ class StickyCommands : JavaPlugin(), StickyCommands {
 
     override fun onLoad() {
         plugin = this
+        CommandAPI.onLoad(true)
         postgresHandler = PostgresHandler()
 
         worthTable = WorthTable()
@@ -54,6 +56,7 @@ class StickyCommands : JavaPlugin(), StickyCommands {
     }
 
     override fun onEnable() {
+        CommandAPI.onEnable(this)
         StickyCommands.registerService(this, this)
 
         if (!StickyStartupUtil.setupPlaceholders())


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
StickyCommands does not work currently. CommandAPI cannot be loaded by the plugin.

**Describe the solution you'd like**
Reverting to shading CommandAPI and disabling the CommandAPI plugin should work.

**Additional context**
I can't figure out how to build this locally, some help would be appreciated in that regard
